### PR TITLE
Fix redirect_uri error

### DIFF
--- a/lib/omniauth/strategies/disqus.rb
+++ b/lib/omniauth/strategies/disqus.rb
@@ -32,6 +32,10 @@ module OmniAuth
           :raw_info => raw_info
         }
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
       
       def raw_info
         url    = '/api/3.0/users/details.json'


### PR DESCRIPTION
[omniauth-oauth2](https://github.com/omniauth/omniauth-oauth2) removed the `callback_url` then was falling back to the omniauth-1.3.1 `callback_url` which includes the querystring at the end, here's a snippet:

```
def callback_url
      full_host + script_name + callback_path + query_string
end
```

This will cause the validation to fail on disqus because the urls wouldn't match anymore.

This PR introduces a method `callback_url` with the same implementation.

I know the this library is not updated since 2014 but at least the information would be here if other people is having the same problem.